### PR TITLE
Reorganize and update boilerplate to match latest tomo-plugin recommendations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-performance
+require:
+  - rubocop-minitest
+  - rubocop-performance
 
 AllCops:
   DisplayCopNames: true
@@ -30,7 +32,7 @@ Lint/StructNewOverride:
   Enabled: true
 
 Metrics/AbcSize:
-  Max: 16
+  Max: 20
   Exclude:
     - "test/**/*"
 
@@ -44,6 +46,7 @@ Metrics/ClassLength:
     - "test/**/*"
 
 Metrics/MethodLength:
+  Max: 18
   Exclude:
     - "test/**/*"
 
@@ -71,6 +74,9 @@ Style/DoubleNegation:
 Style/EmptyMethod:
   Enabled: false
 
+Style/FormatStringToken:
+  Enabled: false
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 
@@ -85,6 +91,9 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: true
+
+Style/NumericPredicate:
+  Enabled: false
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/tomo-plugin-nvm.svg)](https://rubygems.org/gems/tomo-plugin-nvm)
 [![Travis](https://img.shields.io/travis/mattbrictson/tomo-plugin-nvm.svg?label=travis)](https://travis-ci.org/mattbrictson/tomo-plugin-nvm)
-[![Circle](https://circleci.com/gh/mattbrictson/tomo-plugin-nvm.svg?style=shield)](https://circleci.com/gh/mattbrictson/tomo-plugin-nvm)
+[![Circle](https://circleci.com/gh/mattbrictson/tomo-plugin-nvm.svg?style=shield)](https://app.circleci.com/pipelines/github/mattbrictson/tomo-plugin-nvm?branch=master)
 [![Code Climate](https://codeclimate.com/github/mattbrictson/tomo-plugin-nvm/badges/gpa.svg)](https://codeclimate.com/github/mattbrictson/tomo-plugin-nvm)
 
 This is a [tomo](https://github.com/mattbrictson/tomo) plugin to manage node and yarn via nvm (instead of using the [nodenv tasks](https://tomo-deploy.com/plugins/nodenv/) that are built into tomo). The `nvm:install` task is a drop-in replacement for tomo’s `nodenv:install` task.

--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,7 @@ namespace :bump do
     version = Gem.latest_version_for("bundler").to_s
     replace_in_file ".circleci/config.yml", /bundler -v (\S+)/ => version
     replace_in_file ".travis.yml", /bundler -v (\S+)/ => version
+    replace_in_file "Gemfile.lock", /^BUNDLED WITH\n\s+([\d\.]+)$/ => version
   end
 
   task :ruby do

--- a/lib/tomo/plugin/nvm.rb
+++ b/lib/tomo/plugin/nvm.rb
@@ -2,15 +2,13 @@ require "tomo"
 require_relative "nvm/tasks"
 require_relative "nvm/version"
 
-module Tomo::Plugin
-  module Nvm
-    extend Tomo::PluginDSL
+module Tomo::Plugin::Nvm
+  extend Tomo::PluginDSL
 
-    defaults bashrc_path: ".bashrc",
-             nvm_version: "0.34.0",
-             nvm_node_version: nil,
-             nvm_yarn_version: nil
+  defaults bashrc_path: ".bashrc",
+           nvm_version: "0.34.0",
+           nvm_node_version: nil,
+           nvm_yarn_version: nil
 
-    tasks Tomo::Plugin::Nvm::Tasks
-  end
+  tasks Tomo::Plugin::Nvm::Tasks
 end

--- a/lib/tomo/plugin/nvm/version.rb
+++ b/lib/tomo/plugin/nvm/version.rb
@@ -1,7 +1,8 @@
 module Tomo
   module Plugin
-    module Nvm
-      VERSION = "0.1.0".freeze
-    end
   end
+end
+
+module Tomo::Plugin::Nvm
+  VERSION = "0.1.0".freeze
 end

--- a/tomo-plugin-nvm.gemspec
+++ b/tomo-plugin-nvm.gemspec
@@ -1,7 +1,6 @@
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "tomo/plugin/nvm/version"
-require "English"
 
 Gem::Specification.new do |spec|
   spec.name          = "tomo-plugin-nvm"
@@ -21,7 +20,7 @@ Gem::Specification.new do |spec|
   }
 
   # Specify which files should be added to the gem when it is released.
-  spec.files = `git ls-files exe lib LICENSE.txt README.md`.split($RS)
+  spec.files = `git ls-files -z exe lib LICENSE.txt README.md`.split("\x0")
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
@@ -36,5 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-reporters", "~> 1.3"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rubocop", "0.81.0"
+  spec.add_development_dependency "rubocop-minitest", "0.8.1"
   spec.add_development_dependency "rubocop-performance", "1.5.2"
 end


### PR DESCRIPTION
- Add rubocop-minitest
- Loosen up rubocop guidelines
- Point to new CircleCI pipelines UI
- Declare `Tomo::Plugin::Nvm` instead of using nested module syntax