### PR TITLE
Reformat Ruby files for line length of 120

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,8 +19,7 @@ Layout/HashAlignment:
     - key
 
 Layout/LineLength:
-  Exclude:
-    - "*.gemspec"
+  Max: 120
 
 Layout/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space

--- a/Rakefile
+++ b/Rakefile
@@ -31,12 +31,9 @@ namespace :bump do
     lowest_minor = RubyVersions.lowest_supported_minor
     latest = RubyVersions.latest
 
-    replace_in_file "tomo-plugin-nvm.gemspec",
-                    /ruby_version = ">= (.*)"/ => lowest
-
+    replace_in_file "tomo-plugin-nvm.gemspec", /ruby_version = ">= (.*)"/ => lowest
     replace_in_file ".rubocop.yml", /TargetRubyVersion: (.*)/ => lowest_minor
-    replace_in_file ".circleci/config.yml",
-                    %r{circleci/ruby:([\d\.]+)} => latest
+    replace_in_file ".circleci/config.yml", %r{circleci/ruby:([\d\.]+)} => latest
 
     travis = YAML.safe_load(open(".travis.yml"))
     travis["rvm"] = RubyVersions.latest_supported_patches + ["ruby-head"]
@@ -87,9 +84,7 @@ module RubyVersions
 
     def versions
       @_versions ||= begin
-        yaml = URI.open(
-          "https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/downloads.yml"
-        )
+        yaml = URI.open("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/downloads.yml")
         YAML.safe_load(yaml, symbolize_names: true)
       end
     end

--- a/lib/tomo/plugin/nvm/tasks.rb
+++ b/lib/tomo/plugin/nvm/tasks.rb
@@ -16,8 +16,7 @@ module Tomo::Plugin::Nvm
       require_setting :nvm_version
 
       nvm_version = settings[:nvm_version]
-      install_url = "https://raw.githubusercontent.com/creationix/nvm/"\
-                    "v#{nvm_version}/install.sh"
+      install_url = "https://raw.githubusercontent.com/creationix/nvm/v#{nvm_version}/install.sh"
       remote.run("curl -o- #{install_url.shellescape} | bash")
     end
 
@@ -36,9 +35,7 @@ module Tomo::Plugin::Nvm
       require_setting :nvm_node_version
       node_version = settings[:nvm_node_version]
 
-      unless node_installed?(node_version)
-        remote.run "nvm", "install", node_version
-      end
+      remote.run "nvm", "install", node_version unless node_installed?(node_version)
       remote.run "nvm", "alias", "default", node_version
     end
 


### PR DESCRIPTION
The rubocop community has decided to standardize on 120 characters for default line length.

https://github.com/rubocop-hq/rubocop/pull/7952

Update rubocop config and reformat ruby files to embrace this convention.