### PR TITLE
Simplify test dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "minitest", "~> 5.11"
-gem "minitest-ci", "~> 3.4"
-gem "minitest-reporters", "~> 1.3"
+gem "minitest-rg", "~> 5.3"
 gem "rake", "~> 13.0"
 gem "rubocop", "1.58.0"
 gem "rubocop-minitest", "0.33.0"

--- a/test/support/ci.rb
+++ b/test/support/ci.rb
@@ -1,2 +1,0 @@
-# Generate XML test reports that can be parsed by CI
-require "minitest/ci" if ENV["CI"]

--- a/test/support/reporters.rb
+++ b/test/support/reporters.rb
@@ -1,2 +1,0 @@
-require "minitest/reporters"
-Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new, ENV, Minitest.backtrace_filter)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,4 +3,4 @@ require "tomo/plugin/nvm"
 require "tomo/testing"
 
 require "minitest/autorun"
-Dir[File.expand_path("support/**/*.rb", __dir__)].each { |rb| require(rb) }
+require "minitest/rg"


### PR DESCRIPTION
- Remove `minitest-ci` since it is not used by GitHub Actions
- Remove `minitest-reporters` in favor of `minitest-rg`, which is simpler, is officially maintained by the minitest GitHub organization, and doesn't patch minitest internals in ways that can break other plugins
- Remove now unneeded `test/support` directory