### PR TITLE
Drop support for Ruby 3.0 (EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
+        ruby: ["3.1", "3.2", "3.3", "head"]
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   Exclude:
     - "tmp/**/*"
     - "vendor/**/*"

--- a/test/tomo/plugin/nvm/tasks_test.rb
+++ b/test/tomo/plugin/nvm/tasks_test.rb
@@ -76,6 +76,6 @@ class Tomo::Plugin::Nvm::TasksTest < Minitest::Test
   private
 
   def configure(settings={})
-    Tomo::Testing::MockPluginTester.new("nvm", settings: settings)
+    Tomo::Testing::MockPluginTester.new("nvm", settings:)
   end
 end

--- a/tomo-plugin-nvm.gemspec
+++ b/tomo-plugin-nvm.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary = "A tomo plugin to manage node and yarn via nvm"
   spec.homepage = "https://github.com/mattbrictson/tomo-plugin-nvm"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/mattbrictson/tomo-plugin-nvm/issues",


### PR DESCRIPTION
- Adopt Ruby 3.1+ implicit hash syntax